### PR TITLE
drop query string

### DIFF
--- a/src/OpenApiV3Validator.php
+++ b/src/OpenApiV3Validator.php
@@ -93,7 +93,7 @@ class OpenApiV3Validator implements OpenApiValidatorInterface
         string $contentType = 'application/json'
     ): bool {
         if (!$this->emptyResponseExpected($responseCode)) {
-            $responseSchemaPath = $this->getResponseSchemaPath($pathName, $method, $responseCode, $contentType);
+            $responseSchemaPath = $this->getResponseSchemaPath(preg_replace('/\?.*/', '', $pathName), $method, $responseCode, $contentType);
             $responseJson = json_decode($response->getBody());
             $this->jsonSchemaValidator->validate($responseJson, (object) ['$ref' => $responseSchemaPath]);
         }

--- a/tests/unit/OpenApiV3ValidatorTest.php
+++ b/tests/unit/OpenApiV3ValidatorTest.php
@@ -146,4 +146,16 @@ class OpenApiV3ValidatorTest extends TestCase
             )
         );
     }
+
+    public function testValidatorDropsQueryString()
+    {
+        $this->assertTrue(
+            $this->validator->validateResponse(
+                $this->mockResponse(200, ['health' => 'ok']),
+                '/check/health?thisis=fine',
+                'GET',
+                200
+            )
+        );
+    }
 }


### PR DESCRIPTION
### Ticket(s):
Link to ticket: NA

### What has been done:
Validator was using entire pathname when searching for a schema related to path, i.e.
`Path "/v1/affiliate/metrics/click?to=2018-09-05&from=2018-08-05"  does not exist in schema (PaddleHq\OpenApiValidator\Exception\PathNotFoundException)`

Using preg_replace, all query strings are dropped from pathnames now before running through the validator.

### How to test:
check the unit tests for the validator to see this in action.

### NB. 
Should we be testing that the query string params are present in the accepted path params of the json????
